### PR TITLE
Ensure FS permissions do not block exit

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,6 @@ node_modules
 test
 .gitignore
 .npmignore
+.travis.yml
 package-lock.json
 README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "v8"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 API and CLI for querying and manipulating host files.
 
+![Build Status](https://travis-ci.org/godaddy/hostwriter.svg?branch=master)
 
 ## Installation
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,7 +51,7 @@ function handleResetCommand(...hosts) {
   return hostfile.point(hosts.reduce((mapping, host) => Object.assign(mapping, { [host]: null }), {}));
 }
 
-Promise.resolve((function (args) {
+module.exports = Promise.resolve((function (args) {
   const command = args.shift();
   switch (command) {
     case 'help':

--- a/lib/host-writer.js
+++ b/lib/host-writer.js
@@ -45,7 +45,7 @@ module.exports = class HostWriter {
           .catch(err => {
             console.warn(
               'Could not automatically reset host file entry. Make sure the file is writable to enable this feature.',
-              err.stack);
+              err.message);
           })
           .then(() => {
             process.exit(1); // eslint-disable-line no-process-exit

--- a/lib/host-writer.js
+++ b/lib/host-writer.js
@@ -41,9 +41,15 @@ module.exports = class HostWriter {
   untilExit(hosts) {
     return this.point(hosts).then(() => {
       const resetAndExit = () => {
-        return this.point(mapObject(hosts, () => null)).then(() => {
-          process.exit(1); // eslint-disable-line no-process-exit
-        });
+        return this.point(mapObject(hosts, () => null))
+          .catch(err => {
+            console.warn(
+              'Could not automatically reset host file entry. Make sure the file is writable to enable this feature.',
+              err.stack);
+          })
+          .then(() => {
+            process.exit(1); // eslint-disable-line no-process-exit
+          });
       };
 
       process

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@godaddy/hostfile",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "scripts": {
     "pretest": "eslint ./lib ./test",
-    "test": "nyc mocha --recursive ./test"
+    "test": "nyc mocha --recursive ./test/specs"
   }
 }

--- a/test/specs/cli.tests.js
+++ b/test/specs/cli.tests.js
@@ -1,5 +1,5 @@
 const proxyquire = require('proxyquire');
-const { match, stub } = require('sinon');
+const { match, spy } = require('sinon');
 const { expect } = require('chai');
 const { Writable } = require('stream');
 const FsStub = require('../stubs/fs');
@@ -9,8 +9,8 @@ describe('The command-line interface', () => {
   let fs, writtenFile;
 
   beforeEach(() => {
-    stub(console, 'log');
-    stub(console, 'error');
+    spy(console, 'log');
+    spy(console, 'error');
 
     fs = new FsStub();
     stubWriteStream();
@@ -166,7 +166,7 @@ describe('The command-line interface', () => {
   }
 
   function invokeCLI() {
-    proxyquire.noCallThru()('../../lib/cli', {
+    return proxyquire.noPreserveCache().noCallThru()('../../lib/cli', {
       './host-writer': proxyquire.noCallThru()('../../lib/host-writer', { fs })
     });
   }


### PR DESCRIPTION
Catch errors writing to the host file on exit with the untilExit method, and do not block the process exit.