### PR TITLE
fix: Use 'net' package for IP Address validation

### DIFF
--- a/lib/entry-types/parse.js
+++ b/lib/entry-types/parse.js
@@ -1,4 +1,4 @@
-const ip = require('ip');
+const net = require('net');
 const HostEntry = require('./host-entry');
 const CommentedHostEntry = require('./commented-host-entry');
 const CommentLine = require('./comment-line');
@@ -16,7 +16,7 @@ module.exports = function parseHostFileLine(text) {
 
   if (hasContent) {
     const [address, ...hosts] = content.split(/\s+/).filter(Boolean);
-    if (address && hosts && hosts.length && (ip.isV4Format(address) || ip.isV6Format(address))) {
+    if (address && hosts && hosts.length && (net.isIPv4(address) || net.isIPv6(address))) {
       return new HostEntry(address, hosts, comment);
     }
     return new InvalidEntry(text);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@godaddy/hostfile",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@godaddy/hostfile",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "API and CLI for querying and manipulating host files",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
When consuming this package in, `hostfile-menu`, certain comments were getting incorrectly classified as host entries when the first word was also a valid hexidecimal number. See all entries with 'DCC', and 'Added' in the screenshot.
![image](https://user-images.githubusercontent.com/86264310/145304400-6a346e1f-9f17-4430-bd46-e89ae45c4058.png)

The root cause of this is a faulty regex in the `ip` module's `isV6Format` method. This package hasn't been updated in 5 years, so rather than submit a fix to them, I decided to swap that dependency for Node's native, `net` module.